### PR TITLE
Add: I Added network selector to support mainnet contracts

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -7,6 +7,7 @@ import { FunctionForm } from "@/components/function-form";
 import { RecentContracts } from "@/components/recent-contracts";
 import { TxResult } from "@/components/tx-result";
 import { WalletConnect } from "@/components/wallet-connect";
+import { NetworkToggle } from "@/components/network-toggle";
 import { useContract } from "@/hooks/use-contract";
 import { useWallet } from "@/hooks/use-wallet";
 import { argsFromValues, invokeCall, simulateCall } from "@/lib/invocation";
@@ -15,7 +16,7 @@ import {
   getRecentContracts,
   removeRecentContract,
 } from "@/lib/recent-contracts";
-import { appNetwork } from "@/lib/stellar-client";
+import { defaultNetwork, type StellarNetwork } from "@/lib/stellar-client";
 
 export default function Home() {
   const {
@@ -26,10 +27,12 @@ export default function Home() {
     selectedFunction,
     selectFunction,
     load,
+    network: contractNetwork,
   } = useContract();
 
   const wallet = useWallet();
 
+  const [selectedNetwork, setSelectedNetwork] = useState<StellarNetwork>(defaultNetwork);
   const [callLoading, setCallLoading] = useState(false);
   const [callResult, setCallResult] = useState<unknown>(null);
   const [callError, setCallError] = useState<string | null>(null);
@@ -57,7 +60,7 @@ export default function Home() {
   };
 
   const handleSimulate = async (values: Record<string, string>) => {
-    if (!metadata || !selectedFunction) return;
+    if (!metadata || !selectedFunction || !contractNetwork) return;
 
     setCallLoading(true);
     resetCallState();
@@ -68,7 +71,8 @@ export default function Home() {
         metadata.contractId,
         selectedFunction.name,
         args,
-        wallet.address ?? undefined
+        wallet.address ?? undefined,
+        contractNetwork
       );
       setCallResult(result);
     } catch (err) {
@@ -79,7 +83,7 @@ export default function Home() {
   };
 
   const handleInvoke = async (values: Record<string, string>) => {
-    if (!metadata || !selectedFunction || !wallet.address) return;
+    if (!metadata || !selectedFunction || !wallet.address || !contractNetwork) return;
 
     setCallLoading(true);
     resetCallState();
@@ -90,7 +94,8 @@ export default function Home() {
         metadata.contractId,
         selectedFunction.name,
         args,
-        wallet.address
+        wallet.address,
+        contractNetwork
       );
       setTxHash(hash);
       setCallResult(value);
@@ -104,7 +109,7 @@ export default function Home() {
   return (
     <main className="min-h-screen px-6 py-10">
       <div className="max-w-4xl mx-auto">
-        <header className="mb-8 flex items-start justify-between gap-4">
+        <header className="mb-8 flex items-center justify-between gap-4 flex-wrap">
           <div>
             <h1 className="text-2xl font-semibold mb-1">
               Soroban Contract Explorer
@@ -113,33 +118,37 @@ export default function Home() {
               Paste a contract ID to view and call its functions.
             </p>
           </div>
-          <WalletConnect
-            address={wallet.address}
-            network={wallet.network}
-            connecting={wallet.connecting}
-            error={wallet.error}
-            onConnect={wallet.connect}
-            onDisconnect={wallet.disconnect}
-          />
+          <div className="flex items-center gap-4 flex-wrap">
+            <NetworkToggle network={selectedNetwork} onChange={setSelectedNetwork} />
+            <WalletConnect
+              address={wallet.address}
+              network={wallet.network}
+              connecting={wallet.connecting}
+              error={wallet.error}
+              onConnect={wallet.connect}
+              onDisconnect={wallet.disconnect}
+            />
+          </div>
         </header>
 
         {wallet.address &&
           wallet.network &&
-          wallet.network !== appNetwork && (
+          contractNetwork &&
+          wallet.network !== contractNetwork && (
             <div className="mb-6 border border-yellow-900 bg-yellow-950/30 rounded p-3 text-xs text-yellow-200">
               Your wallet is on{" "}
               <span className="capitalize font-medium">{wallet.network}</span>{" "}
-              but this app is configured for{" "}
-              <span className="capitalize font-medium">{appNetwork}</span>.
+              but this contract is on{" "}
+              <span className="capitalize font-medium">{contractNetwork}</span>.
               Switch networks in Freighter before submitting transactions.
             </div>
           )}
 
         <section className="mb-8 flex flex-col gap-4">
-          <ContractSearch onSearch={load} loading={loading} />
+          <ContractSearch onSearch={(id) => load(id, selectedNetwork)} loading={loading} />
           <RecentContracts
             contracts={recents}
-            onSelect={load}
+            onSelect={(id) => load(id, selectedNetwork)}
             onRemove={handleRemoveRecent}
           />
         </section>
@@ -183,6 +192,7 @@ export default function Home() {
                   result={callResult}
                   txHash={txHash}
                   error={callError}
+                  network={contractNetwork}
                 />
               </div>
             </div>

--- a/src/components/network-toggle.tsx
+++ b/src/components/network-toggle.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import type { StellarNetwork } from "@/lib/stellar-client";
+
+interface Props {
+  network: StellarNetwork;
+  onChange: (network: StellarNetwork) => void;
+}
+
+export function NetworkToggle({ network, onChange }: Props) {
+  return (
+    <div className="flex items-center bg-neutral-950/80 backdrop-blur-md border border-neutral-800 rounded-full p-1 relative shadow-inner select-none">
+      {/* Sliding active indicator */}
+      <div
+        className="absolute top-1 bottom-1 rounded-full bg-neutral-800 transition-all duration-300 ease-out shadow-md border border-neutral-700/40"
+        style={{
+          left: network === "testnet" ? "4px" : "calc(50% + 2px)",
+          width: "calc(50% - 6px)",
+        }}
+      />
+      
+      <button
+        type="button"
+        onClick={() => onChange("testnet")}
+        className={`relative z-10 px-3 py-1.5 text-[11px] font-semibold tracking-wider rounded-full transition-colors duration-200 uppercase ${
+          network === "testnet" ? "text-neutral-100" : "text-neutral-500 hover:text-neutral-300"
+        }`}
+        style={{ width: "75px", textAlign: "center" }}
+      >
+        Testnet
+      </button>
+      
+      <button
+        type="button"
+        onClick={() => onChange("mainnet")}
+        className={`relative z-10 px-3 py-1.5 text-[11px] font-semibold tracking-wider rounded-full transition-colors duration-200 uppercase ${
+          network === "mainnet" ? "text-neutral-100" : "text-neutral-500 hover:text-neutral-300"
+        }`}
+        style={{ width: "75px", textAlign: "center" }}
+      >
+        Mainnet
+      </button>
+    </div>
+  );
+}

--- a/src/components/tx-result.tsx
+++ b/src/components/tx-result.tsx
@@ -6,10 +6,8 @@ interface Props {
   result: unknown;
   txHash: string | null;
   error: string | null;
+  network?: "testnet" | "mainnet" | null;
 }
-
-const NETWORK = process.env.NEXT_PUBLIC_STELLAR_NETWORK || "testnet";
-const EXPLORER_PATH = NETWORK === "mainnet" ? "public" : "testnet";
 
 function formatValue(value: unknown): string {
   return JSON.stringify(
@@ -43,7 +41,7 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-export function TxResult({ result, txHash, error }: Props) {
+export function TxResult({ result, txHash, error, network }: Props) {
   if (error) {
     return (
       <div className="border border-red-900 bg-red-950/30 rounded p-3 text-xs text-red-300 break-all">
@@ -54,8 +52,9 @@ export function TxResult({ result, txHash, error }: Props) {
 
   if (result === null && !txHash) return null;
 
+  const explorerPath = network === "mainnet" ? "public" : "testnet";
   const explorerUrl = txHash
-    ? `https://stellar.expert/explorer/${EXPLORER_PATH}/tx/${txHash}`
+    ? `https://stellar.expert/explorer/${explorerPath}/tx/${txHash}`
     : null;
 
   return (

--- a/src/hooks/use-contract.ts
+++ b/src/hooks/use-contract.ts
@@ -3,22 +3,26 @@
 import { useState, useCallback } from "react";
 import { loadContractMetadata } from "@/lib/contract-parser";
 import type { ContractMetadata, ContractFunction } from "@/types/contract";
+import type { StellarNetwork } from "@/lib/stellar-client";
 
 export function useContract() {
   const [metadata, setMetadata] = useState<ContractMetadata | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [selectedName, setSelectedName] = useState<string | null>(null);
+  const [network, setNetwork] = useState<StellarNetwork | null>(null);
 
-  const load = useCallback(async (contractId: string) => {
+  const load = useCallback(async (contractId: string, targetNetwork: StellarNetwork) => {
     setLoading(true);
     setError(null);
     setMetadata(null);
     setSelectedName(null);
+    setNetwork(null);
 
     try {
-      const data = await loadContractMetadata(contractId);
+      const data = await loadContractMetadata(contractId, targetNetwork);
       setMetadata(data);
+      setNetwork(targetNetwork);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to load contract");
     } finally {
@@ -39,6 +43,7 @@ export function useContract() {
     error,
     selectedName,
     selectedFunction,
+    network,
     load,
     selectFunction,
   };

--- a/src/lib/contract-parser.ts
+++ b/src/lib/contract-parser.ts
@@ -1,6 +1,6 @@
 import { Contract, xdr } from "@stellar/stellar-sdk";
 import { XdrReader } from "@stellar/js-xdr";
-import { sorobanServer } from "./stellar-client";
+import { getSorobanServer, type StellarNetwork } from "./stellar-client";
 import type {
   ContractFunction,
   ContractMetadata,
@@ -8,8 +8,12 @@ import type {
   SorobanType,
 } from "@/types/contract";
 
-export async function fetchContractWasm(contractId: string): Promise<Buffer> {
+export async function fetchContractWasm(
+  contractId: string,
+  network: StellarNetwork
+): Promise<Buffer> {
   const contract = new Contract(contractId);
+  const sorobanServer = getSorobanServer(network);
 
   const instanceKey = xdr.LedgerKey.contractData(
     new xdr.LedgerKeyContractData({
@@ -138,9 +142,10 @@ function extractFunctions(entries: xdr.ScSpecEntry[]): ContractFunction[] {
 }
 
 export async function loadContractMetadata(
-  contractId: string
+  contractId: string,
+  network: StellarNetwork
 ): Promise<ContractMetadata> {
-  const wasm = await fetchContractWasm(contractId);
+  const wasm = await fetchContractWasm(contractId, network);
   const entries = await extractSpecEntries(wasm);
   const functions = extractFunctions(entries);
   return { contractId, functions };

--- a/src/lib/invocation.ts
+++ b/src/lib/invocation.ts
@@ -10,7 +10,7 @@ import {
   xdr,
 } from "@stellar/stellar-sdk";
 import { signTransaction } from "@stellar/freighter-api";
-import { networkPassphrase, sorobanServer } from "./stellar-client";
+import { getNetworkPassphrase, getSorobanServer, type StellarNetwork } from "./stellar-client";
 import type { FunctionParam, SorobanType } from "@/types/contract";
 
 function valueToScVal(
@@ -71,8 +71,12 @@ export async function simulateCall(
   contractId: string,
   fnName: string,
   args: xdr.ScVal[],
-  sourceAddress?: string
+  sourceAddress: string | undefined,
+  network: StellarNetwork
 ): Promise<unknown> {
+  const sorobanServer = getSorobanServer(network);
+  const passphrase = getNetworkPassphrase(network);
+
   const sourceKey = sourceAddress || Keypair.random().publicKey();
   const account = new Account(sourceKey, "0");
 
@@ -81,7 +85,7 @@ export async function simulateCall(
 
   const tx = new TransactionBuilder(account, {
     fee: BASE_FEE,
-    networkPassphrase,
+    networkPassphrase: passphrase,
   })
     .addOperation(op)
     .setTimeout(30)
@@ -109,8 +113,12 @@ export async function invokeCall(
   contractId: string,
   fnName: string,
   args: xdr.ScVal[],
-  sourceAddress: string
+  sourceAddress: string,
+  network: StellarNetwork
 ): Promise<InvokeResult> {
+  const sorobanServer = getSorobanServer(network);
+  const passphrase = getNetworkPassphrase(network);
+
   const account = await sorobanServer.getAccount(sourceAddress);
 
   const contract = new Contract(contractId);
@@ -118,7 +126,7 @@ export async function invokeCall(
 
   const tx = new TransactionBuilder(account, {
     fee: BASE_FEE,
-    networkPassphrase,
+    networkPassphrase: passphrase,
   })
     .addOperation(op)
     .setTimeout(30)
@@ -127,11 +135,11 @@ export async function invokeCall(
   const prepared = await sorobanServer.prepareTransaction(tx);
 
   const signedXdr = await signTransaction(prepared.toXDR(), {
-    networkPassphrase,
+    networkPassphrase: passphrase,
     accountToSign: sourceAddress,
   });
 
-  const signedTx = TransactionBuilder.fromXDR(signedXdr, networkPassphrase);
+  const signedTx = TransactionBuilder.fromXDR(signedXdr, passphrase);
   const sendResp = await sorobanServer.sendTransaction(signedTx);
 
   if (sendResp.status === "ERROR") {

--- a/src/lib/stellar-client.ts
+++ b/src/lib/stellar-client.ts
@@ -1,15 +1,21 @@
 import { rpc, Networks } from "@stellar/stellar-sdk";
 
-const RPC_URL =
-  process.env.NEXT_PUBLIC_SOROBAN_RPC_URL ||
-  "https://soroban-testnet.stellar.org";
+export type StellarNetwork = "testnet" | "mainnet";
 
-export const appNetwork =
+export const defaultNetwork: StellarNetwork =
   process.env.NEXT_PUBLIC_STELLAR_NETWORK === "mainnet" ? "mainnet" : "testnet";
 
-export const networkPassphrase =
-  appNetwork === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+export function getNetworkPassphrase(network: StellarNetwork): string {
+  return network === "mainnet" ? Networks.PUBLIC : Networks.TESTNET;
+}
 
-export const sorobanServer = new rpc.Server(RPC_URL, {
-  allowHttp: RPC_URL.startsWith("http://"),
-});
+export function getSorobanServer(network: StellarNetwork): rpc.Server {
+  const url =
+    network === "mainnet"
+      ? (process.env.NEXT_PUBLIC_SOROBAN_MAINNET_RPC_URL || "https://mainnet.sorobanrpc.com")
+      : (process.env.NEXT_PUBLIC_SOROBAN_RPC_URL || "https://soroban-testnet.stellar.org");
+
+  return new rpc.Server(url, {
+    allowHttp: url.startsWith("http://"),
+  });
+}


### PR DESCRIPTION
closes #11 

This pull request introduces the ability for users to toggle between Stellar Testnet and Mainnet at runtime. Previously, the application was locked to a single network environment based on the static NEXT_PUBLIC_STELLAR_NETWORK environment variable. By removing this limitation, users can now browse and interact with Soroban contracts on either network without needing rebuilds or separate deployments.

Under the hood, we refactored stellar-client.ts to dynamically resolve both the network passphrases and Soroban RPC servers per request, rather than at module load time. Additionally, the contract metadata loading functions, invocation utilities, and the useContract hook have been updated to accept a network parameter, allowing the application to track exactly which network a loaded contract belongs to.

On the frontend, we added a polished, glassmorphic NetworkToggle component in the header with a sliding indicator. The network mismatch alert has been updated to compare the connected Freighter wallet against the active contract's network rather than a global environment variable. Finally, transaction result explorer links have been updated to direct users to the correct Stellar Expert network environment based on the loaded contract.