### PR TITLE
feat: add shared copy button

### DIFF
--- a/src/components/contract-explorer.tsx
+++ b/src/components/contract-explorer.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { ContractSearch } from "@/components/contract-search";
+import { CopyButton } from "@/components/copy-button";
 import { FunctionList } from "@/components/function-list";
 import { FunctionForm } from "@/components/function-form";
 import { RecentContracts } from "@/components/recent-contracts";
@@ -213,9 +214,15 @@ function ContractExplorerInner({ initialContractId }: Props) {
           {!loading && metadata && (
             <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
               <div>
-                <p className="text-xs text-neutral-500 mb-3 font-mono break-all">
-                  {metadata.contractId}
-                </p>
+                <div className="mb-3 flex items-start justify-between gap-3">
+                  <p className="text-xs text-neutral-500 font-mono break-all">
+                    {metadata.contractId}
+                  </p>
+                  <CopyButton
+                    text={metadata.contractId}
+                    className="shrink-0 text-xs text-neutral-500 hover:text-neutral-300"
+                  />
+                </div>
                 <FunctionList
                   functions={metadata.functions}
                   selected={selectedName}

--- a/src/components/copy-button.tsx
+++ b/src/components/copy-button.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import { useState } from "react";
+
+interface Props {
+  text: string;
+  className?: string;
+}
+
+export function CopyButton({ text, className }: Props) {
+  const [copied, setCopied] = useState(false);
+
+  const handleClick = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // clipboard not available
+    }
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={className ?? "text-xs text-neutral-500 hover:text-neutral-300"}
+    >
+      {copied ? "Copied" : "Copy"}
+    </button>
+  );
+}

--- a/src/components/tx-result.tsx
+++ b/src/components/tx-result.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { CopyButton } from "@/components/copy-button";
 
 interface Props {
   result: unknown;
@@ -14,30 +14,6 @@ function formatValue(value: unknown): string {
     value,
     (_, v) => (typeof v === "bigint" ? v.toString() : v),
     2
-  );
-}
-
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-
-  const handleClick = async () => {
-    try {
-      await navigator.clipboard.writeText(text);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 1200);
-    } catch {
-      // clipboard not available
-    }
-  };
-
-  return (
-    <button
-      type="button"
-      onClick={handleClick}
-      className="text-xs text-neutral-500 hover:text-neutral-300"
-    >
-      {copied ? "Copied" : "Copy"}
-    </button>
   );
 }
 


### PR DESCRIPTION
Closes #20

## Summary
- extract the existing transaction result copy control into `src/components/copy-button.tsx`
- update `TxResult` to use the shared copy button with the same copied/reset feedback
- add a copy button beside the loaded contract ID in the current contract metadata view

## Verification
- `npm run build`
- `git diff --check`

## Note
- The issue mentions `src/app/page.tsx`, but the current app renders the loaded contract ID from `src/components/contract-explorer.tsx`, so the copy button is added there.
