### PR TITLE
feat: add optional nickname for recent contracts

### DIFF
--- a/src/components/contract-explorer.tsx
+++ b/src/components/contract-explorer.tsx
@@ -16,6 +16,8 @@ import {
   addRecentContract,
   getRecentContracts,
   removeRecentContract,
+  updateRecentContractNickname,
+  type RecentContract,
 } from "@/lib/recent-contracts";
 import { defaultNetwork, type StellarNetwork } from "@/lib/stellar-client";
 
@@ -53,7 +55,7 @@ function ContractExplorerInner({ initialContractId }: Props) {
   const [callResult, setCallResult] = useState<unknown>(null);
   const [callError, setCallError] = useState<string | null>(null);
   const [txHash, setTxHash] = useState<string | null>(null);
-  const [recents, setRecents] = useState<string[]>([]);
+  const [recents, setRecents] = useState<RecentContract[]>([]);
 
   // Load contract when ID or Network changes
   useEffect(() => {
@@ -74,6 +76,10 @@ function ContractExplorerInner({ initialContractId }: Props) {
 
   const handleRemoveRecent = (id: string) => {
     setRecents(removeRecentContract(id));
+  };
+
+  const handleUpdateNickname = (id: string, nickname: string) => {
+    setRecents(updateRecentContractNickname(id, nickname));
   };
 
   const resetCallState = () => {
@@ -193,6 +199,7 @@ function ContractExplorerInner({ initialContractId }: Props) {
             contracts={recents}
             onSelect={handleSelectRecent}
             onRemove={handleRemoveRecent}
+            onUpdateNickname={handleUpdateNickname}
           />
         </section>
 

--- a/src/components/recent-contracts.tsx
+++ b/src/components/recent-contracts.tsx
@@ -1,35 +1,86 @@
 "use client";
 
+import { useState } from "react";
+import type { RecentContract } from "@/lib/recent-contracts";
+
 interface Props {
-  contracts: string[];
+  contracts: RecentContract[];
   onSelect: (id: string) => void;
   onRemove: (id: string) => void;
+  onUpdateNickname: (id: string, nickname: string) => void;
 }
 
 function truncate(id: string): string {
   return `${id.slice(0, 6)}...${id.slice(-4)}`;
 }
 
-export function RecentContracts({ contracts, onSelect, onRemove }: Props) {
+export function RecentContracts({ contracts, onSelect, onRemove, onUpdateNickname }: Props) {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editValue, setEditValue] = useState("");
+
   if (contracts.length === 0) return null;
+
+  const handleEdit = (contract: RecentContract) => {
+    setEditingId(contract.id);
+    setEditValue(contract.nickname || "");
+  };
+
+  const handleSave = (id: string) => {
+    onUpdateNickname(id, editValue.trim());
+    setEditingId(null);
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent, id: string) => {
+    if (e.key === "Enter") {
+      handleSave(id);
+    } else if (e.key === "Escape") {
+      setEditingId(null);
+    }
+  };
 
   return (
     <div className="flex flex-col gap-2">
       <p className="text-xs text-neutral-500">Recent</p>
       <div className="flex flex-wrap gap-2">
-        {contracts.map((id) => (
+        {contracts.map((contract) => (
           <div
-            key={id}
+            key={contract.id}
             className="flex items-center gap-1 bg-neutral-900 border border-neutral-800 rounded text-xs"
           >
+            {editingId === contract.id ? (
+              <div className="flex items-center px-2 py-1 gap-1">
+                <input
+                  autoFocus
+                  type="text"
+                  value={editValue}
+                  onChange={(e) => setEditValue(e.target.value)}
+                  onKeyDown={(e) => handleKeyDown(e, contract.id)}
+                  onBlur={() => handleSave(contract.id)}
+                  className="bg-neutral-800 text-neutral-200 border border-neutral-700 rounded px-1 w-24 text-xs outline-none focus:border-neutral-500"
+                />
+              </div>
+            ) : (
+              <div className="flex items-center gap-1 px-2 py-1 group">
+                <button
+                  onClick={() => onSelect(contract.id)}
+                  className="font-mono text-neutral-300 hover:text-neutral-100"
+                >
+                  {contract.nickname || truncate(contract.id)}
+                </button>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleEdit(contract);
+                  }}
+                  className="text-neutral-500 hover:text-neutral-300 opacity-0 group-hover:opacity-100 transition-opacity"
+                  aria-label="Edit nickname"
+                >
+                  <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><path d="M17 3a2.85 2.83 0 1 1 4 4L7.5 20.5 2 22l1.5-5.5Z"/></svg>
+                </button>
+              </div>
+            )}
             <button
-              onClick={() => onSelect(id)}
-              className="px-2 py-1 font-mono text-neutral-300 hover:text-neutral-100"
-            >
-              {truncate(id)}
-            </button>
-            <button
-              onClick={() => onRemove(id)}
+              onClick={() => onRemove(contract.id)}
               className="px-2 py-1 text-neutral-500 hover:text-neutral-300 border-l border-neutral-800"
               aria-label="Remove from recents"
             >

--- a/src/lib/recent-contracts.ts
+++ b/src/lib/recent-contracts.ts
@@ -1,25 +1,45 @@
+export interface RecentContract {
+  id: string;
+  nickname?: string;
+}
+
 const STORAGE_KEY = "soroban-explorer:recent-contracts";
 const MAX_ENTRIES = 10;
 
-export function getRecentContracts(): string[] {
+export function getRecentContracts(): RecentContract[] {
   if (typeof window === "undefined") return [];
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
     if (!raw) return [];
     const parsed = JSON.parse(raw);
-    return Array.isArray(parsed)
-      ? parsed.filter((v) => typeof v === "string")
-      : [];
+    if (!Array.isArray(parsed)) return [];
+    
+    return parsed.map(v => {
+      if (typeof v === "string") {
+        return { id: v };
+      }
+      if (v && typeof v === "object" && typeof v.id === "string") {
+        return { id: v.id, nickname: typeof v.nickname === "string" ? v.nickname : undefined };
+      }
+      return null;
+    }).filter((v): v is RecentContract => v !== null);
   } catch {
     return [];
   }
 }
 
-export function addRecentContract(id: string): string[] {
+export function addRecentContract(id: string, nickname?: string): RecentContract[] {
   if (typeof window === "undefined") return [];
   const current = getRecentContracts();
-  const filtered = current.filter((c) => c !== id);
-  const next = [id, ...filtered].slice(0, MAX_ENTRIES);
+  const existing = current.find(c => c.id === id);
+  const filtered = current.filter((c) => c.id !== id);
+  
+  const nextItem: RecentContract = { 
+    id, 
+    nickname: nickname !== undefined ? nickname : existing?.nickname 
+  };
+  const next = [nextItem, ...filtered].slice(0, MAX_ENTRIES);
+  
   try {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
   } catch {
@@ -28,9 +48,21 @@ export function addRecentContract(id: string): string[] {
   return next;
 }
 
-export function removeRecentContract(id: string): string[] {
+export function removeRecentContract(id: string): RecentContract[] {
   if (typeof window === "undefined") return [];
-  const next = getRecentContracts().filter((c) => c !== id);
+  const next = getRecentContracts().filter((c) => c.id !== id);
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // ignore
+  }
+  return next;
+}
+
+export function updateRecentContractNickname(id: string, nickname: string): RecentContract[] {
+  if (typeof window === "undefined") return [];
+  const current = getRecentContracts();
+  const next = current.map(c => c.id === id ? { ...c, nickname: nickname || undefined } : c);
   try {
     window.localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
   } catch {


### PR DESCRIPTION
Storage & Helpers (src/lib/recent-contracts.ts)

Extended the data model to RecentContract which includes the id and an optional nickname.
Updated the getRecentContracts parsing logic to maintain backward compatibility. It now converts legacy strings (e.g., ["some-id"]) seamlessly to the object structure [{ id: "some-id" }] without errors.
Enhanced addRecentContract to preserve existing nicknames so they aren't wiped when reloading the same contract.
Added a new updateRecentContractNickname helper to update the label by its ID and persist the change to localStorage.
UI & Interaction (src/components/recent-contracts.tsx)

Updated the component to expect the new RecentContract type.
Refactored the UI to display the nickname if present, with a fallback to the truncated ID.
Added a pencil icon that appears on hover next to the contract text, revealing a rename input field.
Built inline edit functionality with keyboard support (Enter to save, Escape to cancel) and onBlur handling to trigger the rename action robustly.
Integration (src/components/contract-explorer.tsx)

Maintained state logic inside contract-explorer.tsx (the core orchestrator for this flow, rather than page.tsx which is just a generic wrapper).
Changed the stored state from string[] to RecentContract[].
Wired up the new handleUpdateNickname callback through the RecentContracts prop interface, ensuring that UI actions accurately trigger updates in local storage and re-render.

Closes #21 