### PR TITLE
docs: add .env.example documenting required environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,8 @@
-# Stellar
+# Default network to load on startup ("testnet" or "mainnet"). Defaults to "testnet" if unset.
 NEXT_PUBLIC_STELLAR_NETWORK=testnet
-NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
+
+# Soroban RPC endpoint for testnet. Defaults to the public Stellar testnet RPC if unset.
 NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+
+# Soroban RPC endpoint for mainnet. Defaults to the public Soroban mainnet RPC if unset.
+NEXT_PUBLIC_SOROBAN_MAINNET_RPC_URL=https://mainnet.sorobanrpc.com


### PR DESCRIPTION
Closes #34
## What was added

`.env.example` listing every environment variable the app actually reads, each with a safe placeholder value and a one-line description.

## How the variable list was derived

Grepped `src/` and config files for `process.env` and `NEXT_PUBLIC_`. Every hit traces to `src/lib/stellar-client.ts`. Three variables are read:

- `NEXT_PUBLIC_STELLAR_NETWORK` — selects default network at startup
- `NEXT_PUBLIC_SOROBAN_RPC_URL` — testnet RPC endpoint
- `NEXT_PUBLIC_SOROBAN_MAINNET_RPC_URL` — mainnet RPC endpoint

A pre-existing `NEXT_PUBLIC_HORIZON_URL` entry was removed as it has no usage in the codebase.

## No secrets committed

All placeholder values are the same public fallback URLs already hardcoded in `stellar-client.ts`. No real credentials or private RPC keys are included.
