### PR TITLE
fix: reset call output on function change by huazhuang80-star

### DIFF
--- a/src/components/contract-explorer.tsx
+++ b/src/components/contract-explorer.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, Suspense } from "react";
+import { useCallback, useState, useEffect, Suspense } from "react";
 import { useRouter, useSearchParams, usePathname } from "next/navigation";
 import { ContractSearch } from "@/components/contract-search";
 import { FunctionList } from "@/components/function-list";
@@ -76,11 +76,15 @@ function ContractExplorerInner({ initialContractId }: Props) {
     setRecents(removeRecentContract(id));
   };
 
-  const resetCallState = () => {
+  const resetCallState = useCallback(() => {
     setCallResult(null);
     setCallError(null);
     setTxHash(null);
-  };
+  }, []);
+
+  useEffect(() => {
+    resetCallState();
+  }, [metadata?.contractId, resetCallState, selectedName]);
 
   const handleSimulate = async (values: Record<string, string>) => {
     if (!metadata || !selectedFunction || !contractNetwork) return;


### PR DESCRIPTION
Closes #25.

## Summary
- clear `callResult`, `callError`, and `txHash` when the selected contract function changes
- also clear stale call output when a new contract is loaded
- keep the existing simulate/invoke reset behavior unchanged

## Validation
- `git diff --check` -> passed (line-ending warning only)

## Local limitation
- This fresh checkout has no `node_modules`, and `npm` is not available in this shell, so I could not run the Next/Jest suite locally.