### PR TITLE
fix(invocation): show readable transaction errors

### DIFF
--- a/src/components/tx-result.tsx
+++ b/src/components/tx-result.tsx
@@ -17,6 +17,10 @@ function formatValue(value: unknown): string {
   );
 }
 
+function formatErrorLines(error: string): string[] {
+  return error.split(/\r?\n/).map((line) => line.trim()).filter(Boolean);
+}
+
 function CopyButton({ text }: { text: string }) {
   const [copied, setCopied] = useState(false);
 
@@ -43,9 +47,18 @@ function CopyButton({ text }: { text: string }) {
 
 export function TxResult({ result, txHash, error, network }: Props) {
   if (error) {
+    const errorLines = formatErrorLines(error);
+
     return (
-      <div className="border border-red-900 bg-red-950/30 rounded p-3 text-xs text-red-300 break-all">
-        {error}
+      <div className="border border-red-900 bg-red-950/30 rounded p-3 text-xs text-red-300">
+        <p className="font-semibold text-red-200">Transaction failed</p>
+        <div className="mt-2 flex flex-col gap-1">
+          {(errorLines.length ? errorLines : ["Unable to complete the transaction."]).map((line) => (
+            <p key={line} className="break-words">
+              {line}
+            </p>
+          ))}
+        </div>
       </div>
     );
   }

--- a/src/lib/invocation.ts
+++ b/src/lib/invocation.ts
@@ -104,6 +104,75 @@ export async function simulateCall(
   return null;
 }
 
+
+type ErrorRecord = Record<string, unknown>;
+
+function isRecord(value: unknown): value is ErrorRecord {
+  return typeof value === "object" && value !== null;
+}
+
+function readableToken(value: unknown): string | null {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  if (typeof value === "boolean") return String(value);
+  return null;
+}
+
+function pickReadableField(value: unknown, keys: string[]): string | null {
+  if (!isRecord(value)) return null;
+
+  for (const key of keys) {
+    const direct = readableToken(value[key]);
+    if (direct) return direct;
+  }
+
+  for (const key of keys) {
+    const nested = value[key];
+    if (isRecord(nested)) {
+      const found = pickReadableField(nested, keys);
+      if (found) return found;
+    }
+  }
+
+  return null;
+}
+
+function formatSubmissionError(errorResult: unknown): string {
+  const code = pickReadableField(errorResult, [
+    "resultCode",
+    "transactionResultCode",
+    "txResultCode",
+    "code",
+    "status",
+    "name",
+  ]);
+  const message = pickReadableField(errorResult, ["message", "error", "reason"]);
+
+  if (code && message && code !== message) {
+    return `Submission failed (${code}): ${message}`;
+  }
+  if (code) return `Submission failed: ${code}`;
+  if (message) return `Submission failed: ${message}`;
+
+  return "Submission failed. The network returned an unreadable transaction error.";
+}
+
+function formatTransactionStatus(status: string, result: unknown): string {
+  const code = pickReadableField(result, [
+    "resultCode",
+    "transactionResultCode",
+    "txResultCode",
+    "code",
+    "name",
+  ]);
+  const normalizedStatus = status.toLowerCase().replace(/_/g, " ");
+
+  if (code) {
+    return `Transaction ${normalizedStatus}: ${code}`;
+  }
+
+  return `Transaction ${normalizedStatus}. No readable result code was returned.`;
+}
 export interface InvokeResult {
   txHash: string;
   value: unknown;
@@ -143,9 +212,7 @@ export async function invokeCall(
   const sendResp = await sorobanServer.sendTransaction(signedTx);
 
   if (sendResp.status === "ERROR") {
-    throw new Error(
-      `Submission failed: ${JSON.stringify(sendResp.errorResult)}`
-    );
+    throw new Error(formatSubmissionError(sendResp.errorResult));
   }
 
   let getResp = await sorobanServer.getTransaction(sendResp.hash);
@@ -157,7 +224,7 @@ export async function invokeCall(
   }
 
   if (getResp.status !== "SUCCESS") {
-    throw new Error(`Transaction ${getResp.status.toLowerCase()}`);
+    throw new Error(formatTransactionStatus(getResp.status, getResp));
   }
 
   const value = getResp.returnValue


### PR DESCRIPTION
Closes #26.

## Summary
- Replaces raw `JSON.stringify(errorResult)` submission failures with a readable message that extracts common status/code/message fields where present.
- Applies the same concise status/code formatting to failed `getTransaction` statuses.
- Updates the transaction result error panel to show readable wrapped lines instead of one raw JSON blob.

## Validation
- Static review of `src/lib/invocation.ts` and `src/components/tx-result.tsx`.
- GitHub compare confirms only the two in-scope files changed.
- No secrets or payment details included.