### PR TITLE
docs: document environment variables

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,9 @@
-# Stellar
+# Selects the active Stellar network. Use "testnet" for local development.
+# Any value other than "mainnet" is treated as testnet by the app.
 NEXT_PUBLIC_STELLAR_NETWORK=testnet
-NEXT_PUBLIC_HORIZON_URL=https://horizon-testnet.stellar.org
+
+# Soroban RPC endpoint used when NEXT_PUBLIC_STELLAR_NETWORK is not "mainnet".
 NEXT_PUBLIC_SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+
+# Soroban RPC endpoint used when NEXT_PUBLIC_STELLAR_NETWORK is "mainnet".
+NEXT_PUBLIC_SOROBAN_MAINNET_RPC_URL=https://mainnet.sorobanrpc.com

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ cp .env.example .env
 npm run dev
 ```
 
+The example environment defaults to Stellar testnet. Set `NEXT_PUBLIC_STELLAR_NETWORK=mainnet` and review the mainnet RPC URL before connecting to production contracts.
+
 Open http://localhost:3000.
 
 ## Documentation

--- a/docs/documentation.md
+++ b/docs/documentation.md
@@ -108,8 +108,8 @@ Configuration is read from environment variables prefixed with `NEXT_PUBLIC_` so
 | Variable | Default | Purpose |
 | --- | --- | --- |
 | `NEXT_PUBLIC_STELLAR_NETWORK` | `testnet` | Selects the network. Any value other than `mainnet` is treated as testnet. |
-| `NEXT_PUBLIC_HORIZON_URL` | `https://horizon-testnet.stellar.org` | Horizon endpoint for the chosen network. |
-| `NEXT_PUBLIC_SOROBAN_RPC_URL` | `https://soroban-testnet.stellar.org` | Soroban RPC endpoint used for all reads and submissions. |
+| `NEXT_PUBLIC_SOROBAN_RPC_URL` | `https://soroban-testnet.stellar.org` | Soroban RPC endpoint used for testnet reads and submissions. |
+| `NEXT_PUBLIC_SOROBAN_MAINNET_RPC_URL` | `https://mainnet.sorobanrpc.com` | Soroban RPC endpoint used when `NEXT_PUBLIC_STELLAR_NETWORK=mainnet`. |
 
 The network passphrase is derived automatically from `NEXT_PUBLIC_STELLAR_NETWORK`. When the value is `mainnet`, the app uses the public network passphrase; otherwise it uses the testnet passphrase.
 


### PR DESCRIPTION
## Summary
- update `.env.example` with comments for the environment variables currently read by the app
- add `NEXT_PUBLIC_SOROBAN_MAINNET_RPC_URL` and remove the unused Horizon example variable
- point README users at the testnet default and keep `docs/documentation.md` aligned with the source

Closes #34.

## Validation
- git diff --check
- confirmed `NEXT_PUBLIC_*` usage with ripgrep across `src`, `.env.example`, README, and docs