### PR TITLE
fix: clear call result and error when switching selected function

### DIFF
--- a/src/components/contract-explorer.tsx
+++ b/src/components/contract-explorer.tsx
@@ -72,6 +72,19 @@ function ContractExplorerInner({ initialContractId }: Props) {
     }
   }, [metadata?.contractId]);
 
+  // Clear stale call output whenever the selected function changes so the
+  // result panel never shows output that belongs to a different function.
+  useEffect(() => {
+    resetCallState();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedName]);
+
+  // Also clear when a brand-new contract is loaded.
+  useEffect(() => {
+    resetCallState();
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [metadata?.contractId]);
+
   const handleRemoveRecent = (id: string) => {
     setRecents(removeRecentContract(id));
   };


### PR DESCRIPTION
Closes #25

## Summary
Selecting a different function (or loading a new contract) left the previous result, txHash, and error on screen — stale output from a different call was visible under the newly-selected function.

- Added a `useEffect` on `selectedName` that calls the existing `resetCallState()` helper
- Added a second `useEffect` on `metadata?.contractId` to clear output when a new contract is loaded
- No new state or logic — `resetCallState()` was already used by `handleSimulate` / `handleInvoke`

## Test plan
- [ ] Simulate a function, then select a different function — result panel clears
- [ ] Submit a transaction, switch function — txHash and result clear
- [ ] Load a new contract — prior output clears
- [ ] Simulating / submitting still shows results correctly