### PR TITLE
feat: accept optional 0x prefix on Bytes inputs

### DIFF
--- a/src/components/function-form.tsx
+++ b/src/components/function-form.tsx
@@ -26,7 +26,7 @@ function placeholderFor(param: FunctionParam): string {
     case "Bool":
       return "true / false";
     case "Bytes":
-      return "hex string (no 0x)";
+      return "hex string (0x prefix optional)";
     case "Vec":
       return `comma-separated ${param.inner ?? "values"}`;
     case "Option":

--- a/src/lib/invocation.ts
+++ b/src/lib/invocation.ts
@@ -11,6 +11,7 @@ import {
 } from "@stellar/stellar-sdk";
 import { signTransaction } from "@stellar/freighter-api";
 import { getNetworkPassphrase, getSorobanServer, type StellarNetwork } from "./stellar-client";
+import { stripHexPrefix } from "./validators";
 import type { FunctionParam, SorobanType } from "@/types/contract";
 
 function valueToScVal(
@@ -40,7 +41,7 @@ function valueToScVal(
     case "Symbol":
       return nativeToScVal(value, { type: "symbol" });
     case "Bytes":
-      return nativeToScVal(Buffer.from(value, "hex"));
+      return nativeToScVal(Buffer.from(stripHexPrefix(value), "hex"));
     case "Address":
       return new Address(value.trim()).toScVal();
     case "Vec": {

--- a/src/lib/validators.ts
+++ b/src/lib/validators.ts
@@ -52,8 +52,12 @@ function validateAddress(value: string): string | null {
   return "Must be a valid Stellar address (G...) or contract ID (C...)";
 }
 
+export function stripHexPrefix(value: string): string {
+  return value.trim().replace(/^0x/i, "");
+}
+
 function validateBytes(value: string): string | null {
-  const trimmed = value.trim();
+  const trimmed = stripHexPrefix(value);
   if (!trimmed) return "Hex string is required";
   if (trimmed.length % 2 !== 0) return "Hex string must have an even length";
   if (!HEX_REGEX.test(trimmed)) return "Only hex characters (0-9, a-f) allowed";


### PR DESCRIPTION
Closes #27

## Summary
Bytes inputs previously rejected values with a leading `0x` prefix, even though most hex tools and block explorers include it. Users had to manually strip the prefix before pasting, which was error-prone.

- **`validators.ts`**: exported `stripHexPrefix()` that strips a leading `0x` (case-insensitive) before validation; `validateBytes` uses it — odd-length and non-hex values are still rejected
- **`invocation.ts`**: `valueToScVal` Bytes branch calls `stripHexPrefix()` before `Buffer.from()` so conversion stays consistent with validation
- **`function-form.tsx`**: placeholder updated to `hex string (0x prefix optional)`

## Test plan
- [ ] `0xdeadbeef` validates and converts correctly
- [ ] `0Xdeadbeef` (uppercase X) also works
- [ ] `deadbeef` (no prefix) still works
- [ ] `0xdeadbee` (odd length after strip) is rejected
- [ ] `0xgggg` (non-hex after strip) is rejected