### PR TITLE
feat: add Open Graph metadata, Twitter card, and favicon links

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,7 +3,26 @@ import "./globals.css";
 
 export const metadata: Metadata = {
   title: "Soroban Contract Explorer",
-  description: "Interact with Soroban contracts without writing code",
+  description:
+    "Inspect and call any Soroban smart contract on Stellar — no code required. Paste a contract ID to view its functions and submit transactions directly from the browser.",
+  openGraph: {
+    title: "Soroban Contract Explorer",
+    description:
+      "Inspect and call any Soroban smart contract on Stellar — no code required.",
+    type: "website",
+    images: [{ url: "/og-image.png", width: 1200, height: 630 }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Soroban Contract Explorer",
+    description:
+      "Inspect and call any Soroban smart contract on Stellar — no code required.",
+    images: ["/og-image.png"],
+  },
+  icons: {
+    icon: "/favicon.ico",
+    shortcut: "/favicon.ico",
+  },
 };
 
 export default function RootLayout({


### PR DESCRIPTION
Closes #29

## Summary
The app shipped with only a `title` and `description` — no favicon, no OG image, no Twitter card. Shared links showed blank previews and browser tabs had a generic icon.

- Extended `metadata` in `layout.tsx` with a richer description
- Added `openGraph` block: title, description, type, image (`/og-image.png` 1200×630)
- Added `twitter` block: `summary_large_image` card
- Added `icons` block pointing to `/favicon.ico`

Maintainers can drop a `1200×630 og-image.png` and `favicon.ico` into `/public` to activate previews and tab icons.

## Test plan
- [ ] Browser tab shows 'Soroban Contract Explorer' title
- [ ] Shared link on Twitter/Slack renders the card title and description
- [ ] Once `/public/og-image.png` is added, preview image appears