### PR TITLE
feat: add Clear button to FunctionForm to reset inputs and result

### DIFF
--- a/src/components/contract-explorer.tsx
+++ b/src/components/contract-explorer.tsx
@@ -229,8 +229,10 @@ function ContractExplorerInner({ initialContractId }: Props) {
                     fn={selectedFunction}
                     walletConnected={!!wallet.address}
                     loading={callLoading}
+                    hasResult={callResult !== null || !!callError || !!txHash}
                     onSimulate={handleSimulate}
                     onInvoke={handleInvoke}
+                    onClear={resetCallState}
                   />
                 ) : (
                   <p className="text-sm text-neutral-500">

--- a/src/components/function-form.tsx
+++ b/src/components/function-form.tsx
@@ -8,8 +8,10 @@ interface Props {
   fn: ContractFunction;
   walletConnected: boolean;
   loading: boolean;
+  hasResult: boolean;
   onSimulate: (values: Record<string, string>) => void;
   onInvoke: (values: Record<string, string>) => void;
+  onClear: () => void;
 }
 
 function placeholderFor(param: FunctionParam): string {
@@ -40,8 +42,10 @@ export function FunctionForm({
   fn,
   walletConnected,
   loading,
+  hasResult,
   onSimulate,
   onInvoke,
+  onClear,
 }: Props) {
   const [values, setValues] = useState<Record<string, string>>({});
   const [errors, setErrors] = useState<Record<string, string | null>>({});
@@ -63,6 +67,9 @@ export function FunctionForm({
 
   const hasErrors = Object.values(errors).some(Boolean);
 
+  const allEmpty = Object.values(values).every((v) => !v);
+  const canClear = !allEmpty || hasResult;
+
   const handleSimulate = (e: FormEvent) => {
     e.preventDefault();
     onSimulate(values);
@@ -70,6 +77,14 @@ export function FunctionForm({
 
   const handleInvoke = () => {
     onInvoke(values);
+  };
+
+  const handleClear = () => {
+    const empty: Record<string, string> = {};
+    fn.params.forEach((p) => (empty[p.name] = ""));
+    setValues(empty);
+    setErrors({});
+    onClear();
   };
 
   return (
@@ -134,6 +149,14 @@ export function FunctionForm({
           className="px-3 py-1.5 bg-neutral-200 text-neutral-900 rounded text-xs font-medium disabled:opacity-50 disabled:cursor-not-allowed"
         >
           Submit
+        </button>
+        <button
+          type="button"
+          onClick={handleClear}
+          disabled={loading || !canClear}
+          className="ml-auto px-3 py-1.5 border border-neutral-700 text-neutral-400 rounded text-xs font-medium hover:text-neutral-200 hover:border-neutral-500 disabled:opacity-30 disabled:cursor-not-allowed transition-colors"
+        >
+          Clear
         </button>
       </div>
     </form>


### PR DESCRIPTION
Closes #32

## Summary
The only way to clear inputs was reloading the page or switching functions. A dedicated Clear button lets users quickly reset everything for a fresh call.

- **`FunctionForm`**: added `onClear` and `hasResult` props; `handleClear()` resets all local input values and validation errors then calls `onClear()`
- **`canClear`** logic: Clear is disabled when all inputs are empty AND there is no result/error/txHash to clear — never disabled for no reason
- **`contract-explorer.tsx`**: passes `hasResult={callResult !== null || !!callError || !!txHash}` and `onClear={resetCallState}`

## Test plan
- [ ] Fill some inputs and simulate — Clear empties all inputs and removes the result
- [ ] Clear is disabled when form is empty and no result is shown
- [ ] Clear is enabled when form has values even if no result yet
- [ ] Clear is enabled when result is shown even if inputs are already empty
- [ ] Clear does nothing to wallet connection or function selection