### PR TITLE
feat(ui): show tx confirmation status while Soroban polls

### DIFF
--- a/src/components/contract-explorer.tsx
+++ b/src/components/contract-explorer.tsx
@@ -11,7 +11,7 @@ import { WalletConnect } from "@/components/wallet-connect";
 import { NetworkToggle } from "@/components/network-toggle";
 import { useContract } from "@/hooks/use-contract";
 import { useWallet } from "@/hooks/use-wallet";
-import { argsFromValues, invokeCall, simulateCall } from "@/lib/invocation";
+import { argsFromValues, invokeCall, simulateCall, type TxStatus } from "@/lib/invocation";
 import {
   addRecentContract,
   getRecentContracts,
@@ -53,6 +53,7 @@ function ContractExplorerInner({ initialContractId }: Props) {
   const [callResult, setCallResult] = useState<unknown>(null);
   const [callError, setCallError] = useState<string | null>(null);
   const [txHash, setTxHash] = useState<string | null>(null);
+  const [txStatus, setTxStatus] = useState<TxStatus | null>(null);
   const [recents, setRecents] = useState<string[]>([]);
 
   // Load contract when ID or Network changes
@@ -80,6 +81,7 @@ function ContractExplorerInner({ initialContractId }: Props) {
     setCallResult(null);
     setCallError(null);
     setTxHash(null);
+    setTxStatus(null);
   };
 
   const handleSimulate = async (values: Record<string, string>) => {
@@ -118,7 +120,8 @@ function ContractExplorerInner({ initialContractId }: Props) {
         selectedFunction.name,
         args,
         wallet.address,
-        contractNetwork
+        contractNetwork,
+        setTxStatus
       );
       setTxHash(hash);
       setCallResult(value);
@@ -243,6 +246,7 @@ function ContractExplorerInner({ initialContractId }: Props) {
                   txHash={txHash}
                   error={callError}
                   network={contractNetwork}
+                  txStatus={callLoading ? txStatus : null}
                 />
               </div>
             </div>

--- a/src/components/tx-result.tsx
+++ b/src/components/tx-result.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { useState } from "react";
+import type { TxStatus } from "@/lib/invocation";
 
 interface Props {
   result: unknown;
   txHash: string | null;
   error: string | null;
   network?: "testnet" | "mainnet" | null;
+  txStatus?: TxStatus | null;
 }
 
 function formatValue(value: unknown): string {
@@ -41,7 +43,34 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-export function TxResult({ result, txHash, error, network }: Props) {
+const STATUS_LABEL: Record<TxStatus, string> = {
+  submitted: "Transaction submitted — waiting for confirmation...",
+  pending: "Pending — polling ledger...",
+  confirmed: "Confirmed",
+  failed: "Failed",
+};
+
+const STATUS_STYLE: Record<TxStatus, string> = {
+  submitted: "border-blue-900 bg-blue-950/30 text-blue-300",
+  pending: "border-yellow-900 bg-yellow-950/30 text-yellow-200",
+  confirmed: "border-green-900 bg-green-950/30 text-green-300",
+  failed: "border-red-900 bg-red-950/30 text-red-300",
+};
+
+function StatusBanner({ status }: { status: TxStatus }) {
+  return (
+    <div
+      className={`border rounded p-3 text-xs flex items-center gap-2 ${STATUS_STYLE[status]}`}
+    >
+      {(status === "submitted" || status === "pending") && (
+        <span className="inline-block w-3 h-3 border border-current border-t-transparent rounded-full animate-spin shrink-0" />
+      )}
+      {STATUS_LABEL[status]}
+    </div>
+  );
+}
+
+export function TxResult({ result, txHash, error, network, txStatus }: Props) {
   if (error) {
     return (
       <div className="border border-red-900 bg-red-950/30 rounded p-3 text-xs text-red-300 break-all">
@@ -50,7 +79,10 @@ export function TxResult({ result, txHash, error, network }: Props) {
     );
   }
 
-  if (result === null && !txHash) return null;
+  if (result === null && !txHash) {
+    if (!txStatus) return null;
+    return <StatusBanner status={txStatus} />;
+  }
 
   const explorerPath = network === "mainnet" ? "public" : "testnet";
   const explorerUrl = txHash
@@ -59,6 +91,10 @@ export function TxResult({ result, txHash, error, network }: Props) {
 
   return (
     <div className="border border-neutral-800 rounded p-3 bg-neutral-950 flex flex-col gap-3">
+      {txStatus && (txStatus === "submitted" || txStatus === "pending") && (
+        <StatusBanner status={txStatus} />
+      )}
+
       {txHash && (
         <div>
           <div className="flex items-center justify-between mb-1">

--- a/src/lib/invocation.ts
+++ b/src/lib/invocation.ts
@@ -104,6 +104,8 @@ export async function simulateCall(
   return null;
 }
 
+export type TxStatus = "submitted" | "pending" | "confirmed" | "failed";
+
 export interface InvokeResult {
   txHash: string;
   value: unknown;
@@ -114,7 +116,8 @@ export async function invokeCall(
   fnName: string,
   args: xdr.ScVal[],
   sourceAddress: string,
-  network: StellarNetwork
+  network: StellarNetwork,
+  onStatus?: (status: TxStatus) => void
 ): Promise<InvokeResult> {
   const sorobanServer = getSorobanServer(network);
   const passphrase = getNetworkPassphrase(network);
@@ -143,22 +146,29 @@ export async function invokeCall(
   const sendResp = await sorobanServer.sendTransaction(signedTx);
 
   if (sendResp.status === "ERROR") {
+    onStatus?.("failed");
     throw new Error(
       `Submission failed: ${JSON.stringify(sendResp.errorResult)}`
     );
   }
 
+  onStatus?.("submitted");
+
   let getResp = await sorobanServer.getTransaction(sendResp.hash);
   let attempts = 0;
   while (getResp.status === "NOT_FOUND" && attempts < 30) {
+    onStatus?.("pending");
     await new Promise((r) => setTimeout(r, 1000));
     getResp = await sorobanServer.getTransaction(sendResp.hash);
     attempts++;
   }
 
   if (getResp.status !== "SUCCESS") {
+    onStatus?.("failed");
     throw new Error(`Transaction ${getResp.status.toLowerCase()}`);
   }
+
+  onStatus?.("confirmed");
 
   const value = getResp.returnValue
     ? scValToNative(getResp.returnValue)


### PR DESCRIPTION
Closes #30

## Summary
During the 5-30s polling wait after submitting a Soroban transaction, the UI showed only a generic spinner with no indication that the transaction had actually been sent.

- **`TxStatus` type** (`submitted | pending | confirmed | failed`) exported from `invocation.ts`
- **`invokeCall()`** accepts an optional `onStatus` callback; fires `submitted` once the network accepts the tx, `pending` on each `getTransaction` poll iteration, then `confirmed` or `failed`
- **`TxResult`** receives a `txStatus` prop and renders a live status banner (animated spinner while pending, colour-coded per state)
- **`contract-explorer.tsx`** stores `txStatus` state, passes `setTxStatus` as the callback, forwards it to `TxResult` only while loading (clears on reset)

## Test plan
- [ ] Submit a tx → banner shows "submitted" immediately after wallet signs
- [ ] Banner transitions to "pending" while polling
- [ ] On success → banner is replaced by tx hash + result
- [ ] On failure → red error message shown
- [ ] Simulate still works (onStatus not used)