### PR TITLE
feat(ui): show estimated resource fee after simulation

### DIFF
--- a/src/components/contract-explorer.tsx
+++ b/src/components/contract-explorer.tsx
@@ -11,7 +11,7 @@ import { WalletConnect } from "@/components/wallet-connect";
 import { NetworkToggle } from "@/components/network-toggle";
 import { useContract } from "@/hooks/use-contract";
 import { useWallet } from "@/hooks/use-wallet";
-import { argsFromValues, invokeCall, simulateCall } from "@/lib/invocation";
+import { argsFromValues, invokeCall, simulateCall, type SimulateResult } from "@/lib/invocation";
 import {
   addRecentContract,
   getRecentContracts,
@@ -53,6 +53,7 @@ function ContractExplorerInner({ initialContractId }: Props) {
   const [callResult, setCallResult] = useState<unknown>(null);
   const [callError, setCallError] = useState<string | null>(null);
   const [txHash, setTxHash] = useState<string | null>(null);
+  const [estimatedFee, setEstimatedFee] = useState<string | null>(null);
   const [recents, setRecents] = useState<string[]>([]);
 
   // Load contract when ID or Network changes
@@ -80,7 +81,12 @@ function ContractExplorerInner({ initialContractId }: Props) {
     setCallResult(null);
     setCallError(null);
     setTxHash(null);
+    setEstimatedFee(null);
   };
+
+  useEffect(() => {
+    setEstimatedFee(null);
+  }, [selectedFunction]);
 
   const handleSimulate = async (values: Record<string, string>) => {
     if (!metadata || !selectedFunction || !contractNetwork) return;
@@ -90,14 +96,15 @@ function ContractExplorerInner({ initialContractId }: Props) {
 
     try {
       const args = argsFromValues(selectedFunction.params, values);
-      const result = await simulateCall(
+      const { value, minResourceFee }: SimulateResult = await simulateCall(
         metadata.contractId,
         selectedFunction.name,
         args,
         wallet.address ?? undefined,
         contractNetwork
       );
-      setCallResult(result);
+      setCallResult(value);
+      setEstimatedFee(minResourceFee);
     } catch (err) {
       setCallError(err instanceof Error ? err.message : "Simulation failed");
     } finally {
@@ -243,6 +250,7 @@ function ContractExplorerInner({ initialContractId }: Props) {
                   txHash={txHash}
                   error={callError}
                   network={contractNetwork}
+                  estimatedFee={estimatedFee}
                 />
               </div>
             </div>

--- a/src/components/tx-result.tsx
+++ b/src/components/tx-result.tsx
@@ -7,6 +7,7 @@ interface Props {
   txHash: string | null;
   error: string | null;
   network?: "testnet" | "mainnet" | null;
+  estimatedFee?: string | null;
 }
 
 function formatValue(value: unknown): string {
@@ -41,7 +42,14 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-export function TxResult({ result, txHash, error, network }: Props) {
+function formatFee(stroops: string): string {
+  const n = parseInt(stroops, 10);
+  if (isNaN(n)) return `${stroops} stroops`;
+  const xlm = (n / 10_000_000).toFixed(7).replace(/\.?0+$/, "");
+  return `${n.toLocaleString()} stroops (${xlm} XLM)`;
+}
+
+export function TxResult({ result, txHash, error, network, estimatedFee }: Props) {
   if (error) {
     return (
       <div className="border border-red-900 bg-red-950/30 rounded p-3 text-xs text-red-300 break-all">
@@ -80,6 +88,13 @@ export function TxResult({ result, txHash, error, network }: Props) {
           <p className="text-xs font-mono text-neutral-300 break-all">
             {txHash}
           </p>
+        </div>
+      )}
+
+      {estimatedFee && (
+        <div>
+          <p className="text-xs text-neutral-500 mb-1">Estimated resource fee</p>
+          <p className="text-xs font-mono text-neutral-300">{formatFee(estimatedFee)}</p>
         </div>
       )}
 

--- a/src/lib/invocation.ts
+++ b/src/lib/invocation.ts
@@ -67,13 +67,18 @@ export function argsFromValues(
   return params.map((p) => valueToScVal(values[p.name] ?? "", p.type, p.inner));
 }
 
+export interface SimulateResult {
+  value: unknown;
+  minResourceFee: string | null;
+}
+
 export async function simulateCall(
   contractId: string,
   fnName: string,
   args: xdr.ScVal[],
   sourceAddress: string | undefined,
   network: StellarNetwork
-): Promise<unknown> {
+): Promise<SimulateResult> {
   const sorobanServer = getSorobanServer(network);
   const passphrase = getNetworkPassphrase(network);
 
@@ -97,11 +102,16 @@ export async function simulateCall(
     throw new Error(result.error);
   }
 
+  const minResourceFee =
+    "minResourceFee" in result && result.minResourceFee != null
+      ? String(result.minResourceFee)
+      : null;
+
   if ("result" in result && result.result?.retval) {
-    return scValToNative(result.result.retval);
+    return { value: scValToNative(result.result.retval), minResourceFee };
   }
 
-  return null;
+  return { value: null, minResourceFee };
 }
 
 export interface InvokeResult {


### PR DESCRIPTION
Closes #19

## Summary
After simulating a Soroban function call, users saw only the return value and had no preview of what they would pay before signing.

- **`SimulateResult`** interface: `{ value: unknown; minResourceFee: string | null }`  
- **`simulateCall()`** returns both values; extracts `minResourceFee` from the Soroban RPC response (`null` if the field is absent)
- **`contract-explorer.tsx`**: stores `estimatedFee` state; cleared in `resetCallState()` and via `useEffect` on `selectedFunction` change (covers both new function selection and input edits that trigger a new simulation) 
- **`TxResult`**: new optional `estimatedFee` prop; `formatFee()` converts stroops string → `"1,234 stroops (0.0001234 XLM)"`; shown between the tx hash row and the result row

## Test plan
- [ ] Simulate any function → see "Estimated resource fee: N stroops (X XLM)"
- [ ] Select a different function → fee clears immediately
- [ ] Submit (invoke) → fee clears (resetCallState)
- [ ] Simulate that errors → no fee shown
- [ ] Functions with no resource usage return `minResourceFee: null` — section hidden