### PR TITLE
feat: add page metadata, favicon, and Open Graph tags (#29)

### DIFF
--- a/src/app/icon.svg
+++ b/src/app/icon.svg
@@ -1,0 +1,3 @@
+<svg viewBox="0 0 32 32" xmlns="http://www.w3.org/2000/svg">
+  <polygon points="16,2 20,12 31,12 22,19 25,30 16,23 7,30 10,19 1,12 12,12" fill="#7B2FBE"/>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,8 +2,33 @@ import type { Metadata } from "next";
 import "./globals.css";
 
 export const metadata: Metadata = {
+  metadataBase: new URL(process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000"),
   title: "Soroban Contract Explorer",
-  description: "Interact with Soroban contracts without writing code",
+  description:
+    "Interact with any deployed Soroban smart contract on Stellar without writing code.",
+  icons: { icon: "/icon.svg" },
+  openGraph: {
+    title: "Soroban Contract Explorer",
+    description:
+      "Interact with any deployed Soroban smart contract on Stellar without writing code.",
+    type: "website",
+    url: process.env.NEXT_PUBLIC_APP_URL ?? "http://localhost:3000",
+    images: [
+      {
+        url: "/opengraph-image",
+        width: 1200,
+        height: 630,
+        alt: "Soroban Contract Explorer",
+      },
+    ],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: "Soroban Contract Explorer",
+    description:
+      "Interact with any deployed Soroban smart contract on Stellar without writing code.",
+    images: ["/opengraph-image"],
+  },
 };
 
 export default function RootLayout({

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,53 @@
+import { ImageResponse } from "next/og";
+
+export const runtime = "edge";
+export const alt = "Soroban Contract Explorer";
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function Image() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          background: "linear-gradient(135deg, #1a1a2e 0%, #0f3460 100%)",
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          alignItems: "center",
+          justifyContent: "center",
+          fontFamily: "sans-serif",
+        }}
+      >
+        <svg
+          viewBox="0 0 32 32"
+          width={80}
+          height={80}
+          style={{ marginBottom: 24 }}
+        >
+          <polygon
+            points="16,2 20,12 31,12 22,19 25,30 16,23 7,30 10,19 1,12 12,12"
+            fill="#7B2FBE"
+          />
+        </svg>
+        <div
+          style={{
+            width: 64,
+            height: 3,
+            background: "#7B2FBE",
+            borderRadius: 2,
+            marginBottom: 32,
+          }}
+        />
+        <div style={{ fontSize: 64, fontWeight: 700, color: "#ffffff", marginBottom: 16 }}>
+          Soroban Contract Explorer
+        </div>
+        <div style={{ fontSize: 28, color: "#a0aec0" }}>
+          Interact with Stellar smart contracts without writing code
+        </div>
+      </div>
+    ),
+    { ...size }
+  );
+}


### PR DESCRIPTION
Closes #29

Hi maintainer,
Thanks for the opportunity to contribute. Here's what I did:

## Summary

- Added `src/app/icon.svg` — Stellar-branded SVG favicon (purple star, `#7B2FBE`)
- Created `src/app/opengraph-image.tsx` — dynamic OG image via Next.js `ImageResponse` (Edge Runtime)
- Updated `src/app/layout.tsx` — full metadata with `metadataBase`, `openGraph` (title, description, url, image), and `twitter` card

## Screenshots

### Browser tab & favicon
<img width="1919" height="1075" alt="image" src="https://github.com/user-attachments/assets/c6fd624b-9d0a-40d5-946e-a98a42733894" />

### OG Image (`/opengraph-image`)
<img width="1919" height="1077" alt="image" src="https://github.com/user-attachments/assets/35b06c93-8156-448f-ab6f-91594db4c01a" />

### Meta tags (DevTools)
<img width="916" height="445" alt="image" src="https://github.com/user-attachments/assets/ce91a59b-a140-4e76-9208-e9080741fd39" />

### OG validation — Facebook, LinkedIn & X/Twitter
<img width="650" height="576" alt="image" src="https://github.com/user-attachments/assets/3718e272-88ac-4c80-ac5b-270cc5c5169b" />
<img width="652" height="542" alt="image" src="https://github.com/user-attachments/assets/9a6a6824-c244-4e4e-8782-a4a6d8b8f9de" />

## Test plan

- [x] Browser tab shows "Soroban Contract Explorer" as title
- [x] Favicon (purple star) visible in browser tab
- [x] Shared links render title, description, and preview image on Facebook, LinkedIn, and X/Twitter

## Notes

> For production deploys: set `NEXT_PUBLIC_APP_URL` to the deployment URL in Vercel environment variables so `og:url` and `metadataBase` resolve correctly.